### PR TITLE
Fix header redefinition conflict

### DIFF
--- a/arrow_proxy.h
+++ b/arrow_proxy.h
@@ -1,0 +1,11 @@
+#pragma once
+
+// Helper proxy that lets an iterator yield a prvalue *pair* yet still
+// offer operator-> (needed by some algorithms)
+template<class Ref>
+struct arrow_proxy {
+    Ref r;
+    constexpr Ref*       operator->()       noexcept { return &r; }
+    constexpr Ref const* operator->() const noexcept { return &r; }
+};
+

--- a/chunk_map.h
+++ b/chunk_map.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <map>
 #include <vector>
 #include <initializer_list>
@@ -8,15 +10,7 @@
 #include <stdexcept>
 #include <utility>
 
-// Helper proxy that lets an iterator yield a prvalue *pair* yet still
-// offer operator-> (needed by some algorithms)
-template<class Ref>
-struct arrow_proxy {
-    Ref r;
-    constexpr Ref*       operator->()       noexcept { return &r; }
-    constexpr Ref const* operator->() const noexcept
-    { return const_cast<Ref*>(&r); }  // still returns non-const pointer
-};
+#include "arrow_proxy.h"
 
 // ── forward declarations so the class bodies can mention each other ──
 struct GlobalPosition;

--- a/flat_tree_map.h
+++ b/flat_tree_map.h
@@ -1,3 +1,5 @@
+#pragma once
+
 // ──────────────────────────────────────────────────────────────────────────
 //  flat_tree_map<size_t,bool>  – sparse bit-set presented as an ordered map
 //  (single specialisation of a conceptual flat_tree_map template family)
@@ -16,13 +18,7 @@
 #include <iostream>
 #include <vector>
 
-// Helper proxy that lets an iterator yield a prvalue *pair* yet still
-// offer operator-> (needed by some algorithms)
-template<class Ref>
-struct arrow_proxy {
-    Ref r;
-    Ref* operator->() { return &r; }
-};
+#include "arrow_proxy.h"
 
 // ──────────────────────────────────────────────────────────────────────────
 //  Primary template (empty – we only implement the requested specialisation)


### PR DESCRIPTION
## Summary
- add a standalone `arrow_proxy.h`
- include the shared proxy header from both libraries
- add `#pragma once` to headers to avoid double inclusion

## Testing
- `g++ -std=c++23 test_chunk_map.cpp -o test_chunk_map && ./test_chunk_map`
- `g++ -std=c++23 -I. flat_tree_map.h -o flat_test && rm flat_test`
