### PR TITLE
Add operator-> and pointer alias in flat_tree_map iterator

### DIFF
--- a/flat_tree_map.h
+++ b/flat_tree_map.h
@@ -63,8 +63,8 @@ public:
         using iterator_category = std::forward_iterator_tag;
         using value_type        = std::pair<std::size_t, bool>;
         using difference_type   = std::ptrdiff_t;
-        using pointer           = void;
         using reference         = value_type;
+        using pointer           = arrow_proxy<reference>;
 
         iterator() : map_(nullptr), index_(0) {}
         iterator(const flat_tree_map *m, std::size_t idx) : map_(m), index_(idx) {}
@@ -73,6 +73,7 @@ public:
         value_type operator*() const {
             return {index_, true};
         }
+        pointer operator->() const { return pointer{**this}; }
         // Prefix increment: advance to next set bit
         iterator &operator++() {
             if(map_ && index_ < map_->m_capacity) {


### PR DESCRIPTION
## Summary
- make `flat_tree_map::iterator` provide `operator->()` by using `arrow_proxy`

## Testing
- `g++ -std=c++23 -Wall -Wextra -pedantic -x c++ flat_tree_map.h -o ftmtest`
- `./ftmtest`
- `g++ -std=c++23 -Wall -Wextra -pedantic -x c++ chunk_map.h -o cmtest`
- `./cmtest`
