### PR TITLE
Add flyweight_map tests and cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,3 +21,8 @@ add_executable(test_flat_tree_map
     flat_tree_map.h
     arrow_proxy.h
 )
+
+add_executable(test_flyweight_map
+    test_flyweight_map.cpp
+    flyweight_map.h
+)

--- a/flyweight_map.h
+++ b/flyweight_map.h
@@ -136,51 +136,6 @@ private:
     std::unordered_map<T, key_type> value_to_key_;
     std::vector<T> storage_;
 
-    // Verify flyweight_map itself is a forward range
-    static_assert(std::ranges::range<flyweight_map<T>>);
-    static_assert(std::ranges::forward_range<flyweight_map<T>>);
-
-    // Verify iterator compliance explicitly
-    static_assert(std::forward_iterator<const_iterator>);
-    static_assert(std::input_or_output_iterator<const_iterator>);
-    static_assert(std::sentinel_for<const_iterator, const_iterator>);
-
-    // Verify associated types explicitly
-    static_assert(std::same_as<std::ranges::range_value_t<flyweight_map<T>>, value_type>);
-    static_assert(std::same_as<std::iter_value_t<const_iterator>, value_type>);
 };
 
-
-#include <iostream>
-#include <string>
-#include <ranges>
-
-int main() {
-    flyweight_map<std::string> map;
-
-    auto k1 = map.insert("apple");
-    auto k2 = map.insert("banana");
-    auto k3 = map.insert("apple"); // deduplicated
-
-    assert(k1 == k3);  // keys match
-    assert(map.size() == 2);
-
-    // Iterate items (key-value)
-    for (const auto& [key, value] : map) {
-        std::cout << key << ": " << value << '\n';
-    }
-
-    // Using ranges
-    std::cout << "Values only:\n";
-    for (const auto& v : map.values()) {
-        std::cout << v << '\n';
-    }
-
-    // Direct access
-    if (auto v = map.find(k2)) {
-        std::cout << "Found key " << k2 << " -> " << *v << '\n';
-    }
-
-    return 0;
-}
 

--- a/test_flyweight_map.cpp
+++ b/test_flyweight_map.cpp
@@ -1,0 +1,58 @@
+#define DOCTEST_CONFIG_IMPLEMENT
+#include "doctest.h"
+#include "flyweight_map.h"
+#include <string>
+#include <vector>
+#include <algorithm>
+#include <ranges>
+
+namespace checks {
+    using map_t   = flyweight_map<std::string>;
+    using iter_t  = map_t::const_iterator;
+
+    static_assert(std::forward_iterator<iter_t>);
+    static_assert(std::sentinel_for<iter_t, iter_t>);
+    static_assert(std::ranges::forward_range<map_t>);
+    static_assert(std::ranges::common_range<map_t>);
+    static_assert(std::same_as<std::ranges::range_value_t<map_t>, std::pair<const typename map_t::key_type, const std::string>>);
+}
+
+TEST_CASE("deduplicate values and retrieve") {
+    flyweight_map<std::string> map;
+    auto k1 = map.insert("apple");
+    auto k2 = map.insert("banana");
+    auto k3 = map.insert("apple");
+    CHECK(k1 == k3);
+    CHECK(map.size() == 2);
+    CHECK(map.contains(k2));
+    REQUIRE(map.find(k2) != nullptr);
+    CHECK(*map.find(k2) == "banana");
+}
+
+TEST_CASE("iterate items") {
+    flyweight_map<std::string> map;
+    auto k1 = map.insert("a");
+    auto k2 = map.insert("b");
+    std::vector<std::pair<flyweight_map<std::string>::key_type, std::string>> items;
+    for (auto const& [key, val] : map) {
+        items.emplace_back(key, val);
+    }
+    std::vector<std::pair<flyweight_map<std::string>::key_type, std::string>> expected{{k1, "a"}, {k2, "b"}};
+    CHECK(items == expected);
+}
+
+TEST_CASE("ranges views") {
+    flyweight_map<std::string> map;
+    map.insert("x");
+    map.insert("y");
+    std::vector<std::string> vals;
+    std::ranges::copy(map.values(), std::back_inserter(vals));
+    std::vector<std::string> expected{"x", "y"};
+    CHECK(vals == expected);
+}
+
+int main(int argc, char** argv) {
+    doctest::Context context;
+    context.applyCommandLine(argc, argv);
+    return context.run();
+}


### PR DESCRIPTION
## Summary
- remove example and assertions from `flyweight_map.h`
- add a dedicated `test_flyweight_map.cpp`
- build the new test via CMake

## Testing
- `cmake .. && cmake --build .`
- `./test_chunk_map`
- `./test_flat_tree_map`
- `./test_flyweight_map`
