### PR TITLE
Add flyweight_block_map container

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,2 @@
+All classes and methods must have a one line /// @brief comment.
+Member fields must be declared at the end of each class.

--- a/include/flyweight_block_map.h
+++ b/include/flyweight_block_map.h
@@ -1,0 +1,154 @@
+#pragma once
+
+#include "flyweight_map.h"
+#include "arrow_proxy.h"
+#include <array>
+#include <cstddef>
+#include <cassert>
+#include <ranges>
+#include <functional>
+#include <concepts>
+namespace std {
+    template <class T, size_t N>
+    struct hash<array<T, N>> {
+        size_t operator()(const array<T,N>& arr) const noexcept {
+            size_t h = 0;
+            hash<T> hasher;
+            for (const auto& v : arr) {
+                h ^= hasher(v) + 0x9e3779b9 + (h<<6) + (h>>2);
+            }
+            return h;
+        }
+    };
+}
+
+
+// flyweight_block_map provides deduplicated storage for a fixed-size block of
+// values. Internally values are stored in a flyweight_map, and entire blocks
+// of value handles are also deduplicated via another flyweight_map. This
+// enables one level of nested deduplication.
+
+/// @brief Deduplicated fixed-size associative container.
+template <std::integral Key, typename T, std::size_t BlockSize = 8>
+class flyweight_block_map {
+public:
+    /// @brief key type used to access elements.
+    using key_type     = Key;
+    /// @brief mapped value type.
+    using mapped_type  = T;
+    /// @brief key/value pair type returned by iteration.
+    using value_type   = std::pair<const key_type, T>;
+    /// @brief size type of the container.
+    using size_type    = std::size_t;
+
+private:
+    using value_pool_t = flyweight_map<T>;
+    using value_key    = typename value_pool_t::key_type;
+    using block_array  = std::array<value_key, BlockSize>;
+    using block_pool_t = flyweight_map<block_array>;
+    using block_key    = typename block_pool_t::key_type;
+
+    /// @brief Retrieve block array for key.
+    static const block_array& get_block(block_key k) {
+        auto ptr = block_pool_.find(k);
+        assert(ptr && "invalid block key");
+        return *ptr;
+    }
+
+    /// @brief Retrieve value for value handle.
+    static const T& get_value(value_key k) {
+        auto ptr = value_pool_.find(k);
+        assert(ptr && "invalid value key");
+        return *ptr;
+    }
+
+public:
+    /// @brief Construct default block with all values default-initialized.
+    flyweight_block_map() {
+        block_array arr{};
+        value_key def = value_pool_.insert(T{});
+        arr.fill(def);
+        block_ = block_pool_.insert(arr);
+    }
+
+    /// @brief Get value at key.
+    const T& at(const key_type& key) const {
+        auto idx = static_cast<std::size_t>(key);
+        assert(idx < BlockSize);
+        const auto& arr = get_block(block_);
+        return get_value(arr[idx]);
+    }
+
+    /// @brief Indexed read-only access.
+    const T& operator[](const key_type& key) const { return at(key); }
+
+    /// @brief Number of elements in the block.
+    static constexpr size_type size() noexcept { return BlockSize; }
+
+    /// @brief Assign value at key.
+    void set(const key_type& key, const T& val) {
+        auto idx = static_cast<std::size_t>(key);
+        assert(idx < BlockSize);
+        auto arr = get_block(block_);
+        arr[idx] = value_pool_.insert(val);
+        block_ = block_pool_.insert(arr);
+    }
+
+    /// @brief Retrieve internal deduplication key.
+    block_key key() const noexcept { return block_; }
+    class const_iterator {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using iterator_concept  = std::forward_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = flyweight_block_map::value_type;
+        using reference         = std::pair<key_type, const T&>;
+        using pointer           = arrow_proxy<reference>;
+
+        /// @brief Default constructed iterator.
+        const_iterator() = default;
+        /// @brief Construct from parent and starting index.
+        const_iterator(const flyweight_block_map* parent, std::size_t idx)
+            : parent_(parent), index_(idx) {}
+
+        /// @brief Dereference to key/value pair.
+        reference operator*() const {
+            return { static_cast<key_type>(index_), parent_->at(static_cast<key_type>(index_)) };
+        }
+
+        /// @brief Arrow operator for structured bindings.
+        pointer operator->() const { return pointer{ **this }; }
+
+        /// @brief Advance to next element.
+        const_iterator& operator++() { ++index_; return *this; }
+        /// @brief Post-increment.
+        const_iterator operator++(int) { auto tmp = *this; ++(*this); return tmp; }
+
+        /// @brief Equality comparison.
+        bool operator==(const const_iterator& o) const {
+            return parent_ == o.parent_ && index_ == o.index_;
+        }
+        /// @brief Inequality comparison.
+        bool operator!=(const const_iterator& o) const { return !(*this == o); }
+
+    private:
+        const flyweight_block_map* parent_{nullptr};
+        std::size_t index_{0};
+    };
+
+    /// @brief Iterator to first element.
+    const_iterator begin() const noexcept { return const_iterator(this, 0); }
+    /// @brief Iterator past the last element.
+    const_iterator end() const noexcept { return const_iterator(this, BlockSize); }
+
+    /// @brief Begin iterator ADL helper.
+    friend const_iterator begin(const flyweight_block_map& b) noexcept { return b.begin(); }
+    /// @brief End iterator ADL helper.
+    friend const_iterator end(const flyweight_block_map& b) noexcept { return b.end(); }
+
+private:
+    inline static value_pool_t value_pool_{};
+    inline static block_pool_t block_pool_{};
+    block_key block_{};
+};
+

--- a/tests/test_flyweight_block_map.cpp
+++ b/tests/test_flyweight_block_map.cpp
@@ -1,0 +1,56 @@
+#include "doctest.h"
+#include "flyweight_block_map.h"
+#include <vector>
+#include <algorithm>
+#include <ranges>
+
+namespace checks {
+    using block_t  = flyweight_block_map<std::size_t, int>;
+    using citer_t  = block_t::const_iterator;
+
+    static_assert(std::forward_iterator<citer_t>);
+    static_assert(std::sentinel_for<citer_t, citer_t>);
+    static_assert(std::ranges::forward_range<block_t>);
+    static_assert(std::ranges::common_range<block_t>);
+    static_assert(std::same_as<std::ranges::range_value_t<block_t>,
+                               std::pair<const typename block_t::key_type, int>>);
+}
+
+TEST_CASE("default initialized zeros") {
+    flyweight_block_map<std::size_t, int> b;
+    for(std::size_t i = 0; i < b.size(); ++i) {
+        CHECK(b[i] == 0);
+    }
+}
+
+TEST_CASE("set and retrieve values") {
+    flyweight_block_map<std::size_t, int> b;
+    b.set(3, 42);
+    CHECK(b[3] == 42);
+    b.set(3, 7);
+    CHECK(b[3] == 7);
+}
+
+TEST_CASE("deduplication reacts to mutations") {
+    flyweight_block_map<std::size_t, int> a;
+    flyweight_block_map<std::size_t, int> b;
+    a.set(2, 10);
+    b.set(2, 10);
+    CHECK(a.key() == b.key());
+    b.set(1, 5);
+    CHECK(a.key() != b.key());
+    a.set(1, 5);
+    CHECK(a.key() == b.key());
+}
+
+TEST_CASE("iterate indices") {
+    flyweight_block_map<std::size_t, int> b;
+    b.set(1, 3);
+    std::vector<int> vals;
+    for(auto const& p : b) {
+        vals.push_back(p.second);
+    }
+    std::vector<int> expect{0,3,0,0,0,0,0,0};
+    CHECK(vals == expect);
+}
+


### PR DESCRIPTION
## Summary
- add AGENTS style guidelines
- implement `flyweight_block_map` with map-like interface and deduplicated blocks
- update tests to exercise mutation-based deduplication

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`
