### PR TITLE
Enable chunk_map with flyweight_block_map inner

### DIFF
--- a/include/flyweight_map.h
+++ b/include/flyweight_map.h
@@ -43,12 +43,13 @@ public:
     using size_type = std::size_t;
 
     flyweight_map() {
-        assert(instance_ == nullptr && "Only one flyweight_map instance per type allowed.");
-        instance_ = this;
+        if (!instance_)
+            instance_ = this;
     }
 
     ~flyweight_map() {
-        instance_ = nullptr;
+        if (instance_ == this)
+            instance_ = nullptr;
     }
 
     flyweight_map(const flyweight_map&) = delete;

--- a/tests/test_chunk_map_fb.cpp
+++ b/tests/test_chunk_map_fb.cpp
@@ -1,0 +1,30 @@
+#include "doctest.h"
+#include "chunk_map.h"
+#include "flyweight_block_map.h"
+#include <vector>
+#include <algorithm>
+#include <ranges>
+
+TEST_CASE("chunk_map with flyweight_block_map inner") {
+    using inner_t = flyweight_block_map<LocalPosition, int>;
+    using cm_t = chunk_map<int, inner_t>;
+
+    cm_t cm;
+    cm[GlobalPosition{1}] = 7;       // chunk 0, local 1
+    cm[GlobalPosition{37}] = 3;      // chunk 1, local 5
+    CHECK(cm.size() == 2);
+
+    CHECK(cm.at(GlobalPosition{1}) == 7);
+    CHECK(cm[GlobalPosition{37}] == 3);
+
+    auto it1 = cm.find(GlobalPosition{1});
+    CHECK(it1 != cm.end());
+    CHECK(it1->second == 7);
+    auto it2 = cm.find(GlobalPosition{37});
+    CHECK(it2 != cm.end());
+    CHECK(it2->second == 3);
+
+    cm.erase(GlobalPosition{1});
+    CHECK(cm.size() == 1);
+    CHECK(cm.find(GlobalPosition{1}) == cm.end());
+}

--- a/tests/test_flyweight_block_map.cpp
+++ b/tests/test_flyweight_block_map.cpp
@@ -54,3 +54,10 @@ TEST_CASE("iterate indices") {
     CHECK(vals == expect);
 }
 
+
+TEST_CASE("mutable access via operator[]") {
+    flyweight_block_map<std::size_t, int> b;
+    auto r = b[2];
+    r = 5;
+    CHECK(static_cast<int>(b[2]) == 5);
+}


### PR DESCRIPTION
## Summary
- adapt `chunk_map` accessors and iterators to support proxy references
- enhance `flyweight_block_map` with map‑like APIs and mutable size logic
- relax singleton assertion in `flyweight_map`
- add tests for using `flyweight_block_map` inside `chunk_map`

## Testing
- `cmake ..`
- `make -j8`
- `./tests`
