### PR TITLE
Add VOX output example without binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /build
 /build-clang
+examples/*.vox

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,5 +19,10 @@ target_include_directories(tests PRIVATE
     ${PROJECT_SOURCE_DIR}/tests
 )
 
+add_executable(create_voxel examples/create_voxel.cpp)
+target_include_directories(create_voxel PRIVATE
+    ${PROJECT_SOURCE_DIR}/include
+)
+
 enable_testing()
 add_test(NAME run_tests COMMAND tests)

--- a/examples/create_voxel.cpp
+++ b/examples/create_voxel.cpp
@@ -1,0 +1,18 @@
+#include "magica_voxel_io.h"
+#include "flyweight_block_map.h"
+#include <iostream>
+
+/// @brief Entry point generating a VOX file.
+int main() {
+    using block_t = flyweight_block_map<std::size_t, int>;
+
+    block_t frame;
+    frame.set(0, 1);
+    frame.set(2, 3);
+    frame.set(4, 5);
+
+    magica_voxel_writer<block_t> writer("examples/simple_model.vox");
+    writer.write({frame});
+
+    std::cout << "Wrote examples/simple_model.vox\n";
+}


### PR DESCRIPTION
## Summary
- ignore generated `.vox` files
- remove the committed `simple_model.vox` example output
- keep the example program that produces `examples/simple_model.vox`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `./build/tests`
- `./build/create_voxel`
