### PR TITLE
Unify example with doctest test runner

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,16 +13,14 @@ endif()
 
 file(GLOB TEST_SOURCES CONFIGURE_DEPENDS "tests/*.cpp")
 add_executable(tests ${TEST_SOURCES})
+target_sources(tests PRIVATE examples/create_voxel.cpp)
 
 target_include_directories(tests PRIVATE
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_SOURCE_DIR}/tests
+    ${PROJECT_SOURCE_DIR}/examples
 )
 
-add_executable(create_voxel examples/create_voxel.cpp)
-target_include_directories(create_voxel PRIVATE
-    ${PROJECT_SOURCE_DIR}/include
-)
 
 enable_testing()
 add_test(NAME run_tests COMMAND tests)

--- a/examples/create_voxel.cpp
+++ b/examples/create_voxel.cpp
@@ -1,9 +1,10 @@
+#include "create_voxel.h"
 #include "magica_voxel_io.h"
 #include "flyweight_block_map.h"
 #include <iostream>
 
-/// @brief Entry point generating a VOX file.
-int main() {
+/// @brief Generate a simple VOX file and save it.
+void create_voxel_example() {
     using block_t = flyweight_block_map<std::size_t, int>;
 
     block_t frame;
@@ -11,8 +12,8 @@ int main() {
     frame.set(2, 3);
     frame.set(4, 5);
 
-    magica_voxel_writer<block_t> writer("examples/simple_model.vox");
+    magica_voxel_writer<block_t> writer("simple_model.vox");
     writer.write({frame});
 
-    std::cout << "Wrote examples/simple_model.vox\n";
+    std::cout << "Wrote simple_model.vox\n";
 }

--- a/examples/create_voxel.h
+++ b/examples/create_voxel.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <cstddef>
+
+/// @brief Generate a simple VOX file example.
+void create_voxel_example();

--- a/tests/test_create_voxel.cpp
+++ b/tests/test_create_voxel.cpp
@@ -1,0 +1,6 @@
+#include "doctest.h"
+#include "create_voxel.h"
+
+TEST_CASE("run create_voxel example") {
+    create_voxel_example();
+}


### PR DESCRIPTION
## Summary
- convert example `create_voxel` to a simple function
- include example function in doctest tests
- drop standalone example binary

## Testing
- `cmake .. && cmake --build . && ctest --output-on-failure`