### PR TITLE
Add temp voxel path helper

### DIFF
--- a/examples/create_voxel.cpp
+++ b/examples/create_voxel.cpp
@@ -1,6 +1,7 @@
 #include "create_voxel.h"
 #include "magica_voxel_io.h"
 #include "flyweight_block_map.h"
+#include "temp_voxel_path.h"
 #include <iostream>
 
 /// @brief Generate a simple VOX file and save it.
@@ -12,8 +13,9 @@ void create_voxel_example() {
     frame.set(2, 3);
     frame.set(4, 5);
 
-    magica_voxel_writer<block_t> writer("simple_model.vox");
+    auto path = voxels::make_path("simple_model.vox");
+    magica_voxel_writer<block_t> writer(path.string());
     writer.write({frame});
 
-    std::cout << "Wrote simple_model.vox\n";
+    std::cout << "Wrote " << path << "\n";
 }

--- a/include/temp_voxel_path.h
+++ b/include/temp_voxel_path.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <filesystem>
+#include <string>
+#include <system_error>
+
+namespace voxels {
+
+/// @brief Return path in the temporary voxels directory.
+inline std::filesystem::path make_path(const std::string& name) {
+    auto dir = std::filesystem::temp_directory_path() / "voxels";
+    std::filesystem::create_directories(dir);
+    return dir / name;
+}
+
+/// @brief RAII helper that deletes the file on destruction.
+class temp_file {
+public:
+    /// @brief Construct with file name.
+    explicit temp_file(const std::string& name)
+        : path_(make_path(name)) {}
+
+    /// @brief Remove file when the object goes out of scope.
+    ~temp_file() { std::error_code ec; std::filesystem::remove(path_, ec); }
+
+    /// @brief Access the full path.
+    const std::filesystem::path& path() const noexcept { return path_; }
+
+private:
+    std::filesystem::path path_{};
+};
+
+} // namespace voxels

--- a/tests/test_magica_voxel_io.cpp
+++ b/tests/test_magica_voxel_io.cpp
@@ -1,24 +1,23 @@
 #include "doctest.h"
 #include "magica_voxel_io.h"
-#include <filesystem>
+#include "temp_voxel_path.h"
 
 TEST_CASE("magica_voxel round trip") {
     using block_t = flyweight_block_map<std::size_t, int>;
     block_t map; map.set(2,42); map.set(5,7);
 
-    auto path = std::filesystem::temp_directory_path()/"mv_round.vox";
+    voxels::temp_file tmp("mv_round.vox");
     {
-        magica_voxel_writer<block_t> w(path.string());
+        magica_voxel_writer<block_t> w(tmp.path().string());
         w.write({map});
     }
-    CHECK(std::filesystem::file_size(path) > 0);
+    CHECK(std::filesystem::file_size(tmp.path()) > 0);
 
     {
-        magica_voxel_reader<block_t> r(path.string());
+        magica_voxel_reader<block_t> r(tmp.path().string());
         auto loaded = r.read();
         REQUIRE(loaded.size() == 1);
         CHECK(loaded[0] == map);
     }
-
-    std::filesystem::remove(path);
+    // file removed when tmp goes out of scope
 }


### PR DESCRIPTION
## Summary
- add `temp_voxel_path.h` helper for creating temporary voxel file paths and RAII cleanup
- update example `create_voxel.cpp` to write in unified directory
- use `voxels::temp_file` in voxel IO tests for consistent temp file handling

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `ctest --output-on-failure`
