### PR TITLE
Rewrite bucket_map with packed storage

### DIFF
--- a/include/bucket_map.h
+++ b/include/bucket_map.h
@@ -1,16 +1,18 @@
 #pragma once
 
-#include <map>
-#include <memory>
 #include <limits>
 #include <type_traits>
+#include <vector>
+#include <map>
 #include "arrow_proxy.h"
+#include "flat_vector_array_packed.h"
 
 /// @brief Map storing values in deduplicated buckets.
 template<typename Key, typename T, typename Bucket = std::uint64_t>
 class bucket_map {
     static_assert(std::is_unsigned_v<Bucket>, "Bucket must be unsigned integral");
     static constexpr std::size_t bits_ = std::numeric_limits<Bucket>::digits;
+    using bucket_array = array_packed<bits_, int>;
 public:
     /// @brief Key type used for lookup.
     using key_type    = Key;
@@ -19,12 +21,13 @@ public:
     /// @brief Size type of the container.
     using size_type   = std::size_t;
 
-    /// @brief Node storing a value and bit mask within a bucket.
+    /// @brief Node describing keys with the same value within a bucket.
     struct node {
-        /// @brief Construct node with bucket index and value.
-        node(std::size_t idx, Bucket m, const T& v) : bucket_index(idx), mask(m), value(v) {}
+        /// @brief Bucket index of the node.
         std::size_t bucket_index{};
+        /// @brief Bit mask of keys using the value.
         Bucket mask{};
+        /// @brief Stored value referenced by the mask.
         T value{};
     };
 
@@ -40,136 +43,151 @@ public:
 
         /// @brief Default constructed iterator.
         const_iterator() = default;
-        /// @brief Construct from underlying iterator.
-        explicit const_iterator(typename std::map<key_type, node*>::const_iterator it) : it_(it) {}
+        /// @brief Construct from map and starting key.
+        const_iterator(const bucket_map* m, size_type k) : map_(m), key_(k) { advance(); }
 
         /// @brief Dereference to key/value pair.
-        reference operator*() const { return {it_->first, it_->second->value}; }
+        reference operator*() const { return {key_, map_->values_[map_->value_index_at(key_)]}; }
         /// @brief Arrow operator for structured bindings.
         pointer operator->() const { return pointer{**this}; }
         /// @brief Pre-increment iterator.
-        const_iterator& operator++() { ++it_; return *this; }
+        const_iterator& operator++() { ++key_; advance(); return *this; }
         /// @brief Post-increment iterator.
         const_iterator operator++(int) { auto tmp = *this; ++(*this); return tmp; }
         /// @brief Equality comparison.
-        bool operator==(const const_iterator& o) const { return it_ == o.it_; }
+        bool operator==(const const_iterator& o) const { return key_ == o.key_; }
         /// @brief Inequality comparison.
-        bool operator!=(const const_iterator& o) const { return it_ != o.it_; }
+        bool operator!=(const const_iterator& o) const { return key_ != o.key_; }
     private:
-        typename std::map<key_type, node*>::const_iterator it_{};
+        /// @brief Skip to next used key.
+        void advance() {
+            while (key_ < map_->capacity() && map_->value_index_at(key_) == 0) ++key_;
+        }
+        /// @brief Parent container pointer.
+        const bucket_map* map_{};
+        /// @brief Current key index.
+        size_type key_{};
     };
 
-    /// @brief Container view exposing stored nodes.
+    /// @brief View of nodes computed from buckets.
     class nodes_view {
     public:
-        using map_type       = std::map<std::pair<std::size_t, T>, std::unique_ptr<node>>;
-        using iterator       = typename map_type::iterator;
-        using const_iterator = typename map_type::const_iterator;
+        using vector_type   = std::vector<node>;
+        using const_iterator = typename vector_type::const_iterator;
 
         /// @brief Begin iterator over nodes.
-        iterator begin() noexcept { return map_->begin(); }
-        /// @brief Begin iterator over nodes (const).
-        const_iterator begin() const noexcept { return map_->begin(); }
+        const_iterator begin() const noexcept { return nodes_.begin(); }
         /// @brief End iterator over nodes.
-        iterator end() noexcept { return map_->end(); }
-        /// @brief End iterator over nodes (const).
-        const_iterator end() const noexcept { return map_->end(); }
-
+        const_iterator end() const noexcept { return nodes_.end(); }
     private:
-        explicit nodes_view(map_type& m) : map_(&m) {}
+        explicit nodes_view(vector_type n) : nodes_(std::move(n)) {}
         friend class bucket_map;
-        map_type* map_{};
+        /// @brief Stored collection of nodes.
+        vector_type nodes_{};
     };
 
-    /// @brief Constant view of stored nodes.
-    class const_nodes_view {
-    public:
-        using map_type       = std::map<std::pair<std::size_t, T>, std::unique_ptr<node>>;
-        using const_iterator = typename map_type::const_iterator;
-
-        /// @brief Begin iterator over nodes.
-        const_iterator begin() const noexcept { return map_->begin(); }
-        /// @brief End iterator over nodes.
-        const_iterator end() const noexcept { return map_->end(); }
-
-    private:
-        explicit const_nodes_view(const map_type& m) : map_(&m) {}
-        friend class bucket_map;
-        const map_type* map_{};
-    };
-
-    /// @brief Default constructor.
-    bucket_map() = default;
+    /// @brief Default constructed empty map.
+    bucket_map() { values_.push_back(T{}); }
 
     /// @brief True if container has no elements.
-    bool empty() const noexcept { return key_map_.empty(); }
+    bool empty() const noexcept { return size_ == 0; }
 
     /// @brief Number of stored elements.
-    size_type size() const noexcept { return key_map_.size(); }
+    size_type size() const noexcept { return size_; }
 
     /// @brief Remove all elements.
-    void clear() noexcept { key_map_.clear(); node_map_.clear(); }
+    void clear() noexcept {
+        buckets_.resize(0);
+        values_.clear();
+        values_.push_back(T{});
+        size_ = 0;
+    }
 
     /// @brief Find value at key or throw std::out_of_range.
     const T& at(const key_type& key) const {
-        auto it = key_map_.find(key);
-        if (it == key_map_.end()) throw std::out_of_range("bucket_map::at");
-        return it->second->value;
+        auto idx = value_index_at(key);
+        if (idx == 0) throw std::out_of_range("bucket_map::at");
+        return values_[idx];
     }
 
-    /// @brief Check if key exists.
-    bool contains(const key_type& key) const noexcept { return key_map_.contains(key); }
+    /// @brief Check if key exists in map.
+    bool contains(const key_type& key) const noexcept { return value_index_at(key) != 0; }
 
     /// @brief Insert or assign a value at key.
     void insert_or_assign(const key_type& key, const T& val) {
-        auto idx = static_cast<std::size_t>(key) / bits_;
-        auto bit = static_cast<std::size_t>(key) % bits_;
-        auto pair_key = std::make_pair(idx, val);
-        auto [it, inserted] = node_map_.try_emplace(pair_key, nullptr);
-        if (inserted) it->second = std::make_unique<node>(idx, Bucket{}, val);
-        node* n = it->second.get();
-        Bucket mask_bit = Bucket{1} << bit;
-        if (auto k = key_map_.find(key); k != key_map_.end()) {
-            if (k->second == n) {
-                return; // same value already
-            }
-            erase(key);
+        auto idx = static_cast<size_type>(key) / bits_;
+        auto bit = static_cast<size_type>(key) % bits_;
+        if (idx >= buckets_.size()) buckets_.resize(idx + 1);
+        auto arr = buckets_[idx];
+
+        int val_idx = 0;
+        for (size_type i = 0; i < bits_; ++i) {
+            int vi = arr[i];
+            if (vi != 0 && values_[vi] == val) { val_idx = vi; break; }
         }
-        n->mask |= mask_bit;
-        key_map_[key] = n;
+        if (val_idx == 0) {
+            values_.push_back(val);
+            val_idx = static_cast<int>(values_.size() - 1);
+        }
+        if (arr[bit] == 0) ++size_;
+        arr[bit] = val_idx;
     }
 
     /// @brief Erase key and return count removed.
     size_type erase(const key_type& key) {
-        auto it = key_map_.find(key);
-        if (it == key_map_.end()) return 0;
-        node* n = it->second;
-        auto bit = static_cast<std::size_t>(key) % bits_;
-        n->mask &= ~(Bucket{1} << bit);
-        key_map_.erase(it);
-        if (n->mask == Bucket{}) {
-            auto k = std::make_pair(n->bucket_index, n->value);
-            node_map_.erase(k);
-        }
+        auto idx = static_cast<size_type>(key) / bits_;
+        if (idx >= buckets_.size()) return 0;
+        auto bit = static_cast<size_type>(key) % bits_;
+        auto arr = buckets_[idx];
+        if (arr[bit] == 0) return 0;
+        arr[bit] = 0;
+        --size_;
         return 1;
     }
 
     /// @brief Iterator to first element.
-    const_iterator begin() const noexcept { return const_iterator(key_map_.cbegin()); }
+    const_iterator begin() const noexcept { return const_iterator(this, 0); }
     /// @brief Iterator past last element.
-    const_iterator end() const noexcept { return const_iterator(key_map_.cend()); }
+    const_iterator end() const noexcept { return const_iterator(this, capacity()); }
     /// @brief Begin iterator ADL helper.
     friend const_iterator begin(const bucket_map& m) noexcept { return m.begin(); }
     /// @brief End iterator ADL helper.
     friend const_iterator end(const bucket_map& m) noexcept { return m.end(); }
 
-    /// @brief View of internal nodes.
-    nodes_view nodes() noexcept { return nodes_view(node_map_); }
-    /// @brief Const view of internal nodes.
-    const_nodes_view nodes() const noexcept { return const_nodes_view(node_map_); }
+    /// @brief Compute nodes describing stored values.
+    nodes_view nodes() const {
+        std::vector<node> out;
+        for (size_type idx = 0; idx < buckets_.size(); ++idx) {
+            auto arr = buckets_[idx];
+            std::map<int, Bucket> masks;
+            for (size_type bit = 0; bit < bits_; ++bit) {
+                int vi = arr[bit];
+                if (vi != 0) masks[vi] |= Bucket{1} << bit;
+            }
+            for (auto [vi, mask] : masks) {
+                out.push_back(node{idx, mask, values_[vi]});
+            }
+        }
+        return nodes_view(std::move(out));
+    }
 
 private:
-    std::map<key_type, node*> key_map_{};
-    std::map<std::pair<std::size_t, T>, std::unique_ptr<node>> node_map_{};
+    /// @brief Value index at key or 0 if empty.
+    int value_index_at(size_type key) const noexcept {
+        auto idx = key / bits_;
+        auto bit = key % bits_;
+        if (idx >= buckets_.size()) return 0;
+        return buckets_[idx][bit];
+    }
+
+    /// @brief Total key capacity.
+    size_type capacity() const noexcept { return buckets_.size() * bits_; }
+
+    /// @brief Packed arrays storing value indices per bucket.
+    flat_vector<bucket_array> buckets_{};
+    /// @brief Vector storing unique values.
+    std::vector<T> values_{};
+    /// @brief Current number of stored keys.
+    size_type size_{0};
 };
 

--- a/tests/test_bucket_map.cpp
+++ b/tests/test_bucket_map.cpp
@@ -8,14 +8,12 @@ namespace checks {
     using map_t   = bucket_map<std::size_t, std::string>;
     using iter_t  = map_t::const_iterator;
     using view_t  = map_t::nodes_view;
-    using cview_t = map_t::const_nodes_view;
 
     static_assert(std::forward_iterator<iter_t>);
     static_assert(std::sentinel_for<iter_t, iter_t>);
     static_assert(std::ranges::forward_range<map_t>);
     static_assert(std::ranges::common_range<map_t>);
     static_assert(std::ranges::forward_range<view_t>);
-    static_assert(std::ranges::forward_range<cview_t>);
     static_assert(std::same_as<std::ranges::range_value_t<map_t>,
                                std::pair<const std::size_t, const std::string&>>);
 }
@@ -34,7 +32,7 @@ TEST_CASE("deduplicate nodes in bucket") {
     map.insert_or_assign(2, "x");
     auto nodes = map.nodes();
     CHECK(std::distance(nodes.begin(), nodes.end()) == 1);
-    CHECK(nodes.begin()->second->mask != 0);
+    CHECK(nodes.begin()->mask != 0);
 }
 
 TEST_CASE("iteration order") {
@@ -74,7 +72,7 @@ TEST_CASE("range with empty bucket between") {
     for(std::size_t i = 128; i < 192; ++i) map.insert_or_assign(i, 2);
     auto nodes = map.nodes();
     CHECK(std::distance(nodes.begin(), nodes.end()) == 2);
-    CHECK(std::next(nodes.begin())->first.first == 2); // second bucket index
+    CHECK(std::next(nodes.begin())->bucket_index == 2);
     std::vector<std::size_t> keys;
     for(auto const& [k,v] : map) keys.push_back(k);
     CHECK(keys.front() == 0);


### PR DESCRIPTION
## Summary
- remove unused fields and base bucket_map purely on packed arrays
- compute nodes dynamically from buckets
- adjust tests for new nodes view API

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
