### PR TITLE
Remove morton_position and add Morton ordering

### DIFF
--- a/include/bucket_map.h
+++ b/include/bucket_map.h
@@ -51,7 +51,7 @@ public:
     };
 
     /// @brief Forward iterator over constant elements.
-    class const_iterator {
+class const_iterator {
     public:
         using iterator_category = std::forward_iterator_tag;
         using iterator_concept  = std::forward_iterator_tag;
@@ -66,7 +66,7 @@ public:
         const_iterator(const bucket_map* m, size_type k) : map_(m), key_(k) { advance(); }
 
         /// @brief Dereference to key/value pair.
-        reference operator*() const { return {key_, map_->values_[map_->value_index_at(key_)]}; }
+        reference operator*() const { return {key_type(key_), map_->values_[map_->value_index_at(key_)]}; }
         /// @brief Arrow operator for structured bindings.
         pointer operator->() const { return pointer{**this}; }
         /// @brief Pre-increment iterator.
@@ -87,6 +87,9 @@ public:
         /// @brief Current key index.
         size_type key_{};
     };
+
+    /// @brief Mutable iterator aliasing const_iterator.
+    using iterator = const_iterator;
 
     /// @brief Lazy view providing nodes per bucket.
     class nodes_view {
@@ -284,6 +287,10 @@ public:
     const_iterator begin() const noexcept { return const_iterator(this, 0); }
     /// @brief Iterator past last element.
     const_iterator end() const noexcept { return const_iterator(this, capacity()); }
+    /// @brief Non-const iterator to first element.
+    iterator begin() noexcept { return iterator(this, 0); }
+    /// @brief Non-const iterator past last element.
+    iterator end() noexcept { return iterator(this, capacity()); }
     /// @brief Begin iterator ADL helper.
     friend const_iterator begin(const bucket_map& m) noexcept { return m.begin(); }
     /// @brief End iterator ADL helper.

--- a/include/bucket_map_wrapper.h
+++ b/include/bucket_map_wrapper.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "bucket_map.h"
+
+/// @brief Adapter exposing mutable map interface over bucket_map.
+template<typename Key, typename T, typename Bucket = std::uint64_t>
+class bucket_map_wrapper {
+public:
+    /// @brief Iterator type alias.
+    using iterator = typename bucket_map<Key,T,Bucket>::iterator;
+    /// @brief Const iterator type alias.
+    using const_iterator = typename bucket_map<Key,T,Bucket>::const_iterator;
+
+    /// @brief True if container has no elements.
+    bool empty() const noexcept { return map_.empty(); }
+    /// @brief Number of stored elements.
+    std::size_t size() const noexcept { return map_.size(); }
+
+    /// @brief Access value inserting default if missing.
+    T& operator[](const Key& k) {
+        if(!map_.contains(k)) map_.insert_or_assign(k, T{});
+        return const_cast<T&>(map_.at(k));
+    }
+
+    /// @brief Access existing value.
+    const T& at(const Key& k) const { return map_.at(k); }
+
+    /// @brief Find key returning end if not found.
+    iterator find(const Key& k) {
+        if(!map_.contains(k)) return map_.end();
+        auto it = map_.begin();
+        for(; it != map_.end(); ++it) if(it->first == k) break;
+        return it;
+    }
+    /// @brief Const find key.
+    const_iterator find(const Key& k) const {
+        if(!map_.contains(k)) return map_.end();
+        auto it = map_.begin();
+        for(; it != map_.end(); ++it) if(it->first == k) break;
+        return it;
+    }
+
+    /// @brief Remove key and return count.
+    std::size_t erase(const Key& k) { return map_.erase(k); }
+
+    /// @brief Begin iterator.
+    iterator begin() { return map_.begin(); }
+    /// @brief End iterator.
+    iterator end() { return map_.end(); }
+    /// @brief Const begin iterator.
+    const_iterator begin() const { return map_.begin(); }
+    /// @brief Const end iterator.
+    const_iterator end() const { return map_.end(); }
+
+private:
+    /// @brief Underlying bucket_map.
+    bucket_map<Key,T,Bucket> map_{};
+};
+

--- a/include/chunk_map.h
+++ b/include/chunk_map.h
@@ -9,57 +9,10 @@
 #include <compare>
 #include <stdexcept>
 #include <utility>
+#include <cstddef>
 
 #include "arrow_proxy.h"
-
-// ── forward declarations so the class bodies can mention each other ──
-struct GlobalPosition;
-struct ChunkPosition;
-struct LocalPosition;
-
-// ───────────────── ChunkPosition & LocalPosition – simple bodies ─────
-struct ChunkPosition {
-    int value{};
-    constexpr explicit ChunkPosition(int chunkIdx) : value(chunkIdx) {}
-    constexpr explicit ChunkPosition(GlobalPosition);                 // declared, defined later
-    constexpr auto operator<=>(ChunkPosition const&) const = default;
-    constexpr bool operator==(ChunkPosition const&) const = default;
-};
-
-struct LocalPosition {
-    int value{};
-    constexpr explicit LocalPosition(int localIdx) : value(localIdx & 31) {}
-    constexpr explicit LocalPosition(GlobalPosition);                  // declared, defined later
-    constexpr auto operator<=>(LocalPosition const&) const = default;
-    constexpr bool operator==(LocalPosition const&) const = default;
-};
-
-// ────────────────── GlobalPosition – now can mention C & L ───────────
-struct GlobalPosition {
-    int value{};
-    constexpr explicit GlobalPosition(int v) : value(v) {}
-    constexpr explicit GlobalPosition(ChunkPosition);   // declared, defined later
-    constexpr explicit GlobalPosition(LocalPosition);   // declared, defined later
-
-    constexpr auto operator<=>(GlobalPosition const&) const = default;
-    constexpr bool operator==(GlobalPosition const&) const = default;
-
-    constexpr GlobalPosition operator+(GlobalPosition other) const
-    { return GlobalPosition{ value + other.value }; }
-};
-
-// ────────────────── out-of-class definitions (all types complete) ────
-constexpr ChunkPosition::ChunkPosition(GlobalPosition g)
-    : value(g.value >> 5) {}
-
-constexpr LocalPosition::LocalPosition(GlobalPosition g)
-    : value(g.value & 31) {}
-
-constexpr GlobalPosition::GlobalPosition(ChunkPosition c)
-    : value(c.value << 5) {}
-    
-constexpr GlobalPosition::GlobalPosition(LocalPosition l)
-    : value(l.value) {}
+#include "positions.h"
     
 
 template <

--- a/include/flyweight_block_map.h
+++ b/include/flyweight_block_map.h
@@ -86,7 +86,7 @@ private:
         if constexpr(std::integral<key_type>) {
             return static_cast<std::size_t>(key);
         } else {
-            return static_cast<std::size_t>(key.value);
+            return static_cast<std::size_t>(key) & (BlockSize - 1);
         }
     }
 

--- a/include/layered_map.h
+++ b/include/layered_map.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "chunk_map.h"
+#include "bucket_map_wrapper.h"
+
+/// @brief chunk_map alias using bucket_map for inner storage.
+template<typename T>
+using layered_map = chunk_map<T, bucket_map_wrapper<LocalPosition, T>>;
+

--- a/include/positions.h
+++ b/include/positions.h
@@ -1,0 +1,139 @@
+#pragma once
+
+#include <cstdint>
+#include <compare>
+#include <array>
+#include <cstddef>
+
+/// @brief Morton encode three 10-bit coordinates.
+constexpr std::uint32_t morton_encode(std::uint32_t x, std::uint32_t y, std::uint32_t z)
+{
+    std::uint32_t out = 0;
+    for (unsigned bit = 0; bit < 10; ++bit) {
+        out |= ((x >> bit) & 1u) << (3 * bit);
+        out |= ((y >> bit) & 1u) << (3 * bit + 1);
+        out |= ((z >> bit) & 1u) << (3 * bit + 2);
+    }
+    return out;
+}
+
+/// @brief Decode Morton code into coordinates.
+constexpr std::array<std::uint32_t, 3> morton_decode(std::uint32_t code)
+{
+    std::array<std::uint32_t, 3> p{0,0,0};
+    for (unsigned bit = 0; bit < 10; ++bit) {
+        p[0] |= ((code >> (3 * bit)) & 1u) << bit;
+        p[1] |= ((code >> (3 * bit + 1)) & 1u) << bit;
+        p[2] |= ((code >> (3 * bit + 2)) & 1u) << bit;
+    }
+    return p;
+}
+
+struct GlobalPosition;
+struct ChunkPosition;
+struct LocalPosition;
+
+/// @brief Chunk coordinate of the world.
+struct ChunkPosition {
+    /// @brief X chunk coordinate.
+    std::uint32_t x{};
+    /// @brief Y chunk coordinate.
+    std::uint32_t y{};
+    /// @brief Z chunk coordinate.
+    std::uint32_t z{};
+
+    constexpr ChunkPosition() = default;
+    constexpr ChunkPosition(std::uint32_t xi, std::uint32_t yi, std::uint32_t zi)
+        : x(xi), y(yi), z(zi) {}
+    constexpr explicit ChunkPosition(GlobalPosition gp);
+
+    constexpr auto operator<=>(const ChunkPosition& other) const
+    {
+        return morton_encode(x, y, z) <=> morton_encode(other.x, other.y, other.z);
+    }
+    constexpr bool operator==(const ChunkPosition& other) const = default;
+    /// @brief Convert to size type using Morton code.
+    constexpr operator std::size_t() const { return morton_encode(x, y, z); }
+};
+
+/// @brief Local coordinate within a chunk.
+struct LocalPosition {
+    /// @brief X local coordinate.
+    std::uint32_t x{};
+    /// @brief Y local coordinate.
+    std::uint32_t y{};
+    /// @brief Z local coordinate.
+    std::uint32_t z{};
+
+    constexpr LocalPosition() = default;
+    constexpr explicit LocalPosition(std::uint32_t code)
+    {
+        auto p = morton_decode(code);
+        x = p[0];
+        y = p[1];
+        z = p[2];
+    }
+    constexpr LocalPosition(std::uint32_t xi, std::uint32_t yi, std::uint32_t zi)
+        : x(xi), y(yi), z(zi) {}
+    constexpr explicit LocalPosition(GlobalPosition gp);
+
+    constexpr auto operator<=>(const LocalPosition& other) const
+    {
+        return morton_encode(x, y, z) <=> morton_encode(other.x, other.y, other.z);
+    }
+    constexpr bool operator==(const LocalPosition& other) const = default;
+    /// @brief Convert to size type using Morton code.
+    constexpr operator std::size_t() const { return morton_encode(x, y, z); }
+};
+
+/// @brief Global coordinate in the world.
+struct GlobalPosition {
+    /// @brief X global coordinate.
+    std::uint32_t x{};
+    /// @brief Y global coordinate.
+    std::uint32_t y{};
+    /// @brief Z global coordinate.
+    std::uint32_t z{};
+
+    constexpr GlobalPosition() = default;
+    constexpr explicit GlobalPosition(std::uint32_t code)
+    {
+        auto p = morton_decode(code);
+        x = p[0];
+        y = p[1];
+        z = p[2];
+    }
+    constexpr GlobalPosition(std::uint32_t xi, std::uint32_t yi, std::uint32_t zi)
+        : x(xi), y(yi), z(zi) {}
+    constexpr explicit GlobalPosition(ChunkPosition c);
+    constexpr explicit GlobalPosition(LocalPosition l);
+
+    constexpr auto operator<=>(const GlobalPosition& other) const
+    {
+        return morton_encode(x, y, z) <=> morton_encode(other.x, other.y, other.z);
+    }
+    constexpr bool operator==(const GlobalPosition& other) const = default;
+
+    /// @brief Add coordinates component-wise.
+    constexpr GlobalPosition operator+(GlobalPosition other) const
+    {
+        return GlobalPosition{x + other.x, y + other.y, z + other.z};
+    }
+
+    /// @brief Morton encoded representation.
+    constexpr std::uint32_t encode() const { return morton_encode(x, y, z); }
+};
+
+// ──────── out-of-class definitions ─────────
+constexpr ChunkPosition::ChunkPosition(GlobalPosition gp)
+    : x(gp.x >> 5), y(gp.y >> 5), z(gp.z >> 5) {}
+
+constexpr LocalPosition::LocalPosition(GlobalPosition gp)
+    : x(gp.x & 31), y(gp.y & 31), z(gp.z & 31) {}
+
+constexpr GlobalPosition::GlobalPosition(ChunkPosition c)
+    : x(c.x << 5), y(c.y << 5), z(c.z << 5) {}
+
+constexpr GlobalPosition::GlobalPosition(LocalPosition l)
+    : x(l.x), y(l.y), z(l.z) {}
+

--- a/tests/test_layered_map.cpp
+++ b/tests/test_layered_map.cpp
@@ -1,0 +1,44 @@
+#include "doctest.h"
+#include "layered_map.h"
+#include "positions.h"
+#include <string>
+#include <vector>
+#include <ranges>
+
+namespace checks {
+    using map_t   = layered_map<std::string>;
+    using iter_t  = map_t::iterator;
+    using citer_t = map_t::const_iterator;
+
+    static_assert(std::forward_iterator<iter_t>);
+    static_assert(std::forward_iterator<citer_t>);
+    static_assert(std::sentinel_for<iter_t, iter_t>);
+    static_assert(std::sentinel_for<citer_t, citer_t>);
+    static_assert(std::ranges::forward_range<map_t>);
+    static_assert(std::ranges::common_range<map_t>);
+    static_assert(std::same_as<std::ranges::range_value_t<map_t>,
+                               std::pair<GlobalPosition, std::string>>);
+}
+
+TEST_CASE("layered_map basic insertion") {
+    layered_map<int> lm;
+    lm[GlobalPosition{1,2,3}] = 10;
+    lm[GlobalPosition{33,2,3}] = 20;
+
+    CHECK(lm.size() == 2);
+    CHECK(lm.at(GlobalPosition{1,2,3}) == 10);
+    CHECK(lm.at(GlobalPosition{33,2,3}) == 20);
+}
+
+TEST_CASE("layered_map iteration order") {
+    layered_map<int> lm;
+    lm[GlobalPosition{1,0,0}] = 1;
+    lm[GlobalPosition{0,0,0}] = 0;
+    lm[GlobalPosition{32,0,0}] = 2;
+    std::vector<GlobalPosition> keys;
+    for (auto const& [gp, v] : lm) keys.push_back(gp);
+    CHECK(keys[0] == GlobalPosition{0,0,0});
+    CHECK(keys[1] == GlobalPosition{1,0,0});
+    CHECK(keys[2] == GlobalPosition{32,0,0});
+}
+


### PR DESCRIPTION
## Summary
- drop the old `morton_position` helper
- introduce `positions.h` providing Global/Chunk/LocalPosition with Morton ordering
- make `chunk_map` include the new positions header
- adjust `flyweight_block_map` to work with Morton based positions
- update layered_map tests to use the new position types

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --test-dir . --output-on-failure`
