### PR TITLE
Enable generic MagicaVoxel writer

### DIFF
--- a/examples/create_voxel.cpp
+++ b/examples/create_voxel.cpp
@@ -12,8 +12,8 @@ void create_voxel_example() {
     frame.set(2, 3);
     frame.set(4, 5);
 
-    magica_voxel_writer<block_t> writer("simple_model.vox");
-    writer.write({frame});
+    magica_voxel_writer writer("simple_model.vox");
+    writer.write(frame);
 
     std::cout << "Wrote simple_model.vox\n";
 }

--- a/include/bucket_map.h
+++ b/include/bucket_map.h
@@ -286,7 +286,8 @@ class const_iterator {
             auto arr = other.buckets_[b];
             for (size_type bit = 0; bit < bits_; ++bit) {
                 int vi = arr[bit];
-                if (vi != 0) insert_or_assign(b * bits_ + bit, other.values_[vi]);
+                if (vi != 0) insert_or_assign(static_cast<key_type>(b * bits_ + bit),
+                                             other.values_[vi]);
             }
         }
     }
@@ -308,10 +309,12 @@ class const_iterator {
                 int vi = arr[bit];
                 if (vi != 0) {
                     if (!moved[vi]) {
-                        insert_or_assign(b * bits_ + bit, std::move(other.values_[vi]));
+                        insert_or_assign(static_cast<key_type>(b * bits_ + bit),
+                                         std::move(other.values_[vi]));
                         moved[vi] = true;
                     } else {
-                        insert_or_assign(b * bits_ + bit, other.values_[vi]);
+                        insert_or_assign(static_cast<key_type>(b * bits_ + bit),
+                                         other.values_[vi]);
                     }
                 }
             }

--- a/tests/test_layered_map_intersection.cpp
+++ b/tests/test_layered_map_intersection.cpp
@@ -77,5 +77,5 @@ TEST_CASE("layered_map intersection sphere box") {
   CHECK(bounds.second == expected_bounds.second);
 
     magica_voxel_writer writer("intersection.vox");
-    writer.write({inter});
+    writer.write(inter);
 }

--- a/tests/test_magica_voxel_io.cpp
+++ b/tests/test_magica_voxel_io.cpp
@@ -8,8 +8,8 @@ TEST_CASE("magica_voxel round trip") {
 
     auto path = std::filesystem::temp_directory_path()/"mv_round.vox";
     {
-        magica_voxel_writer<block_t> w(path.string());
-        w.write({map});
+        magica_voxel_writer w(path.string());
+        w.write(map);
     }
     CHECK(std::filesystem::file_size(path) > 0);
 


### PR DESCRIPTION
## Summary
- make `magica_voxel_writer` type independent
- add templated `write` and `write_frames` APIs
- emit clickable `file://` path after writing
- adapt tests and example to new interface
- fix bucket_map copy functions

## Testing
- `cmake --build .`
- `ctest --output-on-failure`