### PR TITLE
Enhance MagicaVoxel writer output path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /build
 /build-clang
 examples/*.vox
+vox_output/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ endif()
 
 file(GLOB TEST_SOURCES CONFIGURE_DEPENDS "tests/*.cpp")
 add_executable(tests ${TEST_SOURCES})
+target_compile_definitions(tests PRIVATE PROJECT_SOURCE_DIR="${PROJECT_SOURCE_DIR}")
 target_sources(tests PRIVATE examples/create_voxel.cpp)
 
 target_include_directories(tests PRIVATE

--- a/examples/create_voxel.cpp
+++ b/examples/create_voxel.cpp
@@ -12,8 +12,8 @@ void create_voxel_example() {
     frame.set(2, 3);
     frame.set(4, 5);
 
-    magica_voxel_writer writer("simple_model.vox");
-    writer.write(frame);
+    magica_voxel_writer writer("simple_model");
+    writer.add_frame(frame);
 
     std::cout << "Wrote simple_model.vox\n";
 }

--- a/include/magica_voxel_io.h
+++ b/include/magica_voxel_io.h
@@ -13,6 +13,7 @@
 #include <type_traits>
 #include <ranges>
 #include <iostream>
+#include <filesystem>
 
 /*
     Excerpt from the official MagicaVoxel 0.99.5 VOX specification
@@ -84,19 +85,27 @@ namespace magica_voxel_detail {
 class magica_voxel_writer {
 public:
     /// @brief Open file for writing.
-    explicit magica_voxel_writer(const std::string& path)
-        : out_(path, std::ios::binary), path_(path)
+    explicit magica_voxel_writer(const std::string& name)
     {
+        namespace fs = std::filesystem;
+        auto base = fs::path(PROJECT_SOURCE_DIR) / "vox_output";
+        fs::create_directories(base);
+        path_ = (base / (name + ".vox")).string();
+        out_.open(path_, std::ios::binary);
         if (!out_) throw std::runtime_error("cannot open output file");
     }
 
-    /// @brief Write a single frame to a VOX file.
+    /// @brief Add a single frame to the VOX file.
     template<typename Map>
-    void write(const Map& frame)
+    void add_frame(const Map& frame)
     {
         std::array<Map,1> tmp{frame};
         write_frames(tmp);
     }
+
+    /// @brief Compatibility wrapper for add_frame.
+    template<typename Map>
+    void write(const Map& frame) { add_frame(frame); }
 
     /// @brief Write a range of map frames to a VOX file.
     template<std::ranges::input_range Range>

--- a/tests/test_layered_map_intersection.cpp
+++ b/tests/test_layered_map_intersection.cpp
@@ -76,6 +76,6 @@ TEST_CASE("layered_map intersection sphere box") {
   CHECK(bounds.first == expected_bounds.first);
   CHECK(bounds.second == expected_bounds.second);
 
-    magica_voxel_writer writer("intersection.vox");
-    writer.write(inter);
+    magica_voxel_writer writer("intersection");
+    writer.add_frame(inter);
 }

--- a/tests/test_magica_voxel_io.cpp
+++ b/tests/test_magica_voxel_io.cpp
@@ -6,10 +6,10 @@ TEST_CASE("magica_voxel round trip") {
     using block_t = flyweight_block_map<std::size_t, int>;
     block_t map; map.set(2,42); map.set(5,7);
 
-    auto path = std::filesystem::temp_directory_path()/"mv_round.vox";
+    auto path = std::filesystem::path(PROJECT_SOURCE_DIR)/"vox_output"/"mv_round.vox";
     {
-        magica_voxel_writer w(path.string());
-        w.write(map);
+        magica_voxel_writer w("mv_round");
+        w.add_frame(map);
     }
     CHECK(std::filesystem::file_size(path) > 0);
 


### PR DESCRIPTION
## Summary
- create an output directory for `.vox` files
- automatically append `.vox` extension when writing
- expose `add_frame` method and keep `write` as a wrapper
- adjust examples and tests to new API
- ignore generated voxel files

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --test-dir . --output-on-failure`
