### PR TITLE
Introduce generic AABB and tests

### DIFF
--- a/include/aabb.h
+++ b/include/aabb.h
@@ -1,0 +1,109 @@
+#pragma once
+
+#include "positions.h"
+#include "arrow_proxy.h"
+#include <cstddef>
+#include <iterator>
+
+/// @brief Axis aligned bounding box using min inclusive and max exclusive.
+template<typename Position>
+class aabb {
+public:
+    using position_type = Position;
+    class iterator;
+    using const_iterator = iterator;
+
+    /// @brief Construct empty box.
+    constexpr aabb() = default;
+    /// @brief Construct from min and max corners.
+    constexpr aabb(Position mi, Position ma) : min_(mi), max_(ma) {}
+
+    /// @brief Minimum inclusive corner.
+    constexpr Position min() const noexcept { return min_; }
+    /// @brief Maximum exclusive corner.
+    constexpr Position max() const noexcept { return max_; }
+    /// @brief Box width.
+    constexpr std::uint32_t width() const noexcept { return max_.x - min_.x; }
+    /// @brief Box height.
+    constexpr std::uint32_t height() const noexcept { return max_.y - min_.y; }
+    /// @brief Box depth.
+    constexpr std::uint32_t depth() const noexcept { return max_.z - min_.z; }
+    /// @brief Number of contained positions.
+    constexpr std::size_t volume() const noexcept {
+        return static_cast<std::size_t>(width()) * height() * depth();
+    }
+    /// @brief Check if position inside box.
+    constexpr bool contains(Position p) const noexcept {
+        return p.x >= min_.x && p.x < max_.x &&
+               p.y >= min_.y && p.y < max_.y &&
+               p.z >= min_.z && p.z < max_.z;
+    }
+
+    /// @brief Begin iterator over contained positions.
+    constexpr iterator begin() const noexcept { return iterator(min_, max_, min_); }
+    /// @brief End iterator over contained positions.
+    constexpr iterator end() const noexcept {
+        Position endPos = min_;
+        endPos.x = max_.x;
+        return iterator(min_, max_, endPos);
+    }
+
+public:
+    /// @brief Forward iterator over box positions.
+    class iterator {
+    public:
+        using iterator_category = std::forward_iterator_tag;
+        using iterator_concept  = std::forward_iterator_tag;
+        using difference_type   = std::ptrdiff_t;
+        using value_type        = Position;
+        using reference         = value_type;
+        using pointer           = arrow_proxy<reference>;
+
+        /// @brief Default constructed iterator.
+        constexpr iterator() = default;
+        /// @brief Construct from bounds and starting position.
+        constexpr iterator(Position mi, Position ma, Position p)
+            : min_(mi), max_(ma), pos_(p) {}
+
+        /// @brief Dereference to current position.
+        constexpr reference operator*() const { return pos_; }
+        /// @brief Arrow operator for structured bindings.
+        constexpr pointer operator->() const { return pointer{**this}; }
+
+        /// @brief Pre-increment iterator.
+        constexpr iterator& operator++() {
+            ++pos_.z;
+            if (pos_.z >= max_.z) {
+                pos_.z = min_.z;
+                ++pos_.y;
+                if (pos_.y >= max_.y) {
+                    pos_.y = min_.y;
+                    ++pos_.x;
+                }
+            }
+            return *this;
+        }
+        /// @brief Post-increment iterator.
+        constexpr iterator operator++(int) { auto t = *this; ++(*this); return t; }
+        /// @brief Equality comparison.
+        constexpr bool operator==(const iterator& o) const {
+            return pos_.x == o.pos_.x && pos_.y == o.pos_.y && pos_.z == o.pos_.z;
+        }
+        /// @brief Inequality comparison.
+        constexpr bool operator!=(const iterator& o) const { return !(*this == o); }
+
+    private:
+        Position min_{}; ///< @brief Inclusive minimum corner.
+        Position max_{}; ///< @brief Exclusive maximum corner.
+        Position pos_{}; ///< @brief Current iterator position.
+    };
+
+private:
+    Position min_{}; ///< @brief Inclusive minimum corner.
+    Position max_{}; ///< @brief Exclusive maximum corner.
+};
+
+using GlobalAabb = aabb<GlobalPosition>;
+using ChunkAabb  = aabb<ChunkPosition>;
+using LocalAabb  = aabb<LocalPosition>;
+

--- a/tests/test_aabb.cpp
+++ b/tests/test_aabb.cpp
@@ -1,0 +1,41 @@
+#include "doctest.h"
+#include "aabb.h"
+#include <vector>
+#include <ranges>
+
+namespace checks {
+    using box_t  = GlobalAabb;
+    using iter_t = box_t::iterator;
+
+    static_assert(std::forward_iterator<iter_t>);
+    static_assert(std::sentinel_for<iter_t, iter_t>);
+    static_assert(std::ranges::forward_range<box_t>);
+    static_assert(std::ranges::common_range<box_t>);
+    static_assert(std::same_as<std::ranges::range_value_t<box_t>, GlobalPosition>);
+}
+
+TEST_CASE("aabb iteration volume") {
+    GlobalAabb box{GlobalPosition{0,0,0}, GlobalPosition{2,2,2}};
+    std::vector<GlobalPosition> vals;
+    for(auto p : box) vals.push_back(p);
+    CHECK(box.volume() == 8);
+    CHECK(vals.size() == box.volume());
+    CHECK(vals.front() == GlobalPosition{0,0,0});
+    CHECK(vals.back() == GlobalPosition{1,1,1});
+}
+
+TEST_CASE("aabb contains") {
+    GlobalAabb box{GlobalPosition{1,1,1}, GlobalPosition{4,3,2}};
+    CHECK(box.contains(GlobalPosition{1,1,1}));
+    CHECK(!box.contains(GlobalPosition{4,2,1}));
+}
+
+TEST_CASE("aabb iterator explicit") {
+    GlobalAabb box{GlobalPosition{0,0,0}, GlobalPosition{2,2,2}};
+    std::vector<GlobalPosition> iter_vals;
+    for(auto it = box.begin(); it != box.end(); ++it) iter_vals.push_back(*it);
+    std::vector<GlobalPosition> range_vals;
+    for(auto p : box) range_vals.push_back(p);
+    CHECK(iter_vals == range_vals);
+}
+

--- a/tests/test_layered_map_intersection.cpp
+++ b/tests/test_layered_map_intersection.cpp
@@ -2,6 +2,7 @@
 #include "layered_map.h"
 #include "magica_voxel_io.h"
 #include "positions.h"
+#include "aabb.h"
 #include <algorithm>
 #include <limits>
 #include <numbers>
@@ -13,10 +14,8 @@ static layered_map<int> make_box(GlobalPosition min_corner,
                                  GlobalPosition max_corner,
                                  int value = 2) {
   layered_map<int> map;
-  for (std::uint32_t x = min_corner.x; x < max_corner.x; ++x)
-    for (std::uint32_t y = min_corner.y; y < max_corner.y; ++y)
-      for (std::uint32_t z = min_corner.z; z < max_corner.z; ++z)
-        map[GlobalPosition{x, y, z}] = value;
+  for (GlobalPosition p : GlobalAabb{min_corner, max_corner})
+    map[p] = value;
   return map;
 }
 


### PR DESCRIPTION
## Summary
- add aabb utility templated on position type
- provide GlobalAabb/ChunkAabb/LocalAabb aliases
- use AABB in layered map intersection test
- add dedicated aabb unit tests
- verify iterator usage and move fields to end of class

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`
