### PR TITLE
Optimize layered_map intersection

### DIFF
--- a/include/layered_map_algo.h
+++ b/include/layered_map_algo.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "layered_map.h"
+#include <map>
+
+/// @brief Write elements common to both layered_maps to output iterator.
+template<typename T, typename OutIt>
+OutIt set_intersection(const layered_map<T>& lhs,
+                       const layered_map<T>& rhs,
+                       OutIt out)
+{
+    chunk_map<T, bucket_map<LocalPosition, T>>::for_each_intersection(
+        lhs, rhs,
+        [&](GlobalPosition gp, const T& val)
+        {
+            *out++ = std::pair{gp, val};
+        });
+    return out;
+}

--- a/tests/test_bucket_map.cpp
+++ b/tests/test_bucket_map.cpp
@@ -133,3 +133,20 @@ TEST_CASE("ranges to move map") {
     CHECK(src.empty());
 }
 
+TEST_CASE("optimized set_intersection") {
+    bucket_map<std::size_t, int> lhs;
+    lhs.insert_or_assign(1, 1);
+    lhs.insert_or_assign(5, 2);
+    lhs.insert_or_assign(70, 3);
+    bucket_map<std::size_t, int> rhs;
+    rhs.insert_or_assign(0, 0);
+    rhs.insert_or_assign(5, 8);
+    rhs.insert_or_assign(70, 9);
+
+    std::vector<std::pair<std::size_t, int>> inter;
+    set_intersection(lhs, rhs, std::back_inserter(inter));
+
+    std::vector<std::pair<std::size_t, int>> expected{{5, 2}, {70, 3}};
+    CHECK(inter == expected);
+}
+

--- a/tests/test_layered_map_intersection.cpp
+++ b/tests/test_layered_map_intersection.cpp
@@ -1,5 +1,6 @@
 #include "doctest.h"
 #include "layered_map.h"
+#include "layered_map_algo.h"
 #include "magica_voxel_io.h"
 #include "positions.h"
 #include "aabb.h"
@@ -63,9 +64,8 @@ TEST_CASE("layered_map intersection sphere box") {
         doctest::Approx(expected_volume).epsilon(0.15));
 
   layered_map<int> inter;
-  std::ranges::set_intersection(
-      box, sphere, std::inserter(inter, inter.end()),
-      [](auto const &a, auto const &b) { return a.first < b.first; });
+  set_intersection(box, sphere,
+                   std::inserter(inter, inter.end()));
 
   layered_map<int> manual;
   for (auto const &[pos, val] : sphere)


### PR DESCRIPTION
## Summary
- add bucket_map::mask_of and for_each_set_bit helpers
- expose bucket_map::for_each_intersection and set_intersection
- add chunk_map::set_intersection wrapper
- implement layered map set_intersection using chunk/bucket helpers
- test the new bucket_map intersection routine

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --test-dir . --output-on-failure`
