### PR TITLE
Implement Core-Expanding Convex Decomposition

### DIFF
--- a/include/layered_map_algo.h
+++ b/include/layered_map_algo.h
@@ -1,6 +1,22 @@
 #pragma once
 #include "layered_map.h"
 #include <map>
+#include <array>
+
+/**
+ * @brief Core expanding convex decomposition utilities.
+ *
+ * Provides voxel morphology helpers (extrude/inset) and the main
+ * core_expanding_convex_decomposition algorithm using layered_map.
+ */
+
+/**
+ * @brief Helper offsets for the six cardinal directions.
+ */
+inline constexpr std::array<std::tuple<int,int,int>,6> cardinal_offsets{
+    std::tuple{ 1, 0, 0}, std::tuple{-1, 0, 0}, std::tuple{0, 1, 0},
+    std::tuple{ 0,-1, 0}, std::tuple{0, 0, 1}, std::tuple{0, 0,-1}
+};
 
 /// @brief Write elements common to both layered_maps to output iterator.
 template<typename T, typename OutIt>
@@ -16,3 +32,115 @@ OutIt set_intersection(const layered_map<T>& lhs,
         });
     return out;
 }
+
+/// @brief Add offset to a position clamping at zero.
+inline bool offset(GlobalPosition p, int dx, int dy, int dz, GlobalPosition& out)
+{
+    auto add = [](std::uint32_t a, int d, std::uint32_t& res) -> bool
+    {
+        int v = static_cast<int>(a) + d;
+        if (v < 0) return false;
+        res = static_cast<std::uint32_t>(v);
+        return true;
+    };
+    std::uint32_t nx, ny, nz;
+    if (!add(p.x, dx, nx) || !add(p.y, dy, ny) || !add(p.z, dz, nz))
+        return false;
+    out = GlobalPosition{nx, ny, nz};
+    return true;
+}
+
+/// @brief Extrude voxels by one unit in all six cardinal directions.
+template<typename T>
+layered_map<T> extrude(layered_map<T> const& map)
+{
+    layered_map<T> out = map;
+    for (auto it = map.cbegin(); it != map.cend(); ++it) {
+        auto const& [gp, val] = *it;
+        for (auto [dx, dy, dz] : cardinal_offsets) {
+            GlobalPosition n;
+            if (offset(gp, dx, dy, dz, n)) out[n] = val;
+        }
+    }
+    return out;
+}
+
+/// @brief Remove boundary voxels leaving the interior.
+template<typename T>
+layered_map<T> inset(layered_map<T> const& map)
+{
+    layered_map<T> out;
+    for (auto it = map.cbegin(); it != map.cend(); ++it) {
+        auto const& [gp, val] = *it;
+        bool all_neighbors = true;
+        for (auto [dx, dy, dz] : cardinal_offsets) {
+            GlobalPosition n;
+            if (!offset(gp, dx, dy, dz, n) || map.find(n) == map.cend()) {
+                all_neighbors = false;
+                break;
+            }
+        }
+        if (all_neighbors) out[gp] = val;
+    }
+    return out;
+}
+
+/// @brief Find the innermost core of a voxel map.
+template<typename T>
+layered_map<T> detect_core(layered_map<T> const& map)
+{
+    layered_map<T> prev = map;
+    layered_map<T> cur  = map;
+    while (!cur.empty()) {
+        prev = cur;
+        cur  = inset(cur);
+    }
+    return prev;
+}
+
+/// @brief Grow a convex layer from a core within the remaining voxels.
+template<typename T>
+layered_map<T> expand_convex(layered_map<T> const& core,
+                             layered_map<T> const& remaining)
+{
+    layered_map<T> hull = core;
+    layered_map<T> front = core;
+    while (true) {
+        front = extrude(front);
+        layered_map<T> added;
+        for (auto const& [gp, v] : front) {
+            auto it = remaining.find(gp);
+            if (it != remaining.cend()) added.insert({gp, it->second});
+        }
+        std::size_t before = hull.size();
+        for (auto const& [gp, v] : added) hull.insert({gp, v});
+        if (hull.size() == before) break;
+        front = added;
+    }
+    return hull;
+}
+
+/// @brief Core-Expanding Convex Decomposition producing layered hulls.
+template<typename T>
+std::vector<layered_map<T>> core_expanding_convex_decomposition(
+    layered_map<T> const& voxels)
+{
+    layered_map<T> remaining = voxels;
+    std::vector<layered_map<T>> layers;
+    while (!remaining.empty()) {
+        auto core = detect_core(remaining);
+        if (core.empty()) {
+            core.insert(*remaining.begin());
+        }
+        auto hull = expand_convex(core, remaining);
+        if (hull.empty()) break;
+        layers.push_back(hull);
+        layered_map<T> next;
+        for (auto it = remaining.cbegin(); it != remaining.cend(); ++it)
+            if (hull.find(it->first) == hull.end())
+                next.insert({it->first, it->second});
+        remaining = std::move(next);
+    }
+    return layers;
+}
+

--- a/tests/test_cecd.cpp
+++ b/tests/test_cecd.cpp
@@ -1,0 +1,78 @@
+#include "doctest.h"
+#include "layered_map.h"
+#include "layered_map_algo.h"
+#include "aabb.h"
+#include <random>
+#include <vector>
+
+/// @brief Create an axis aligned box of voxels.
+static layered_map<int> make_box(GlobalPosition min, GlobalPosition max) {
+    layered_map<int> map;
+    for (GlobalPosition p : GlobalAabb{min, max}) map[p] = 1;
+    return map;
+}
+
+/// @brief Generate synthetic shape from random spheres.
+static layered_map<int> make_random_shape(std::size_t seed) {
+    std::mt19937 gen(seed);
+    std::uniform_int_distribution<int> coord(5, 40);
+    std::uniform_int_distribution<int> radius(2, 6);
+    layered_map<int> map;
+    for (int i = 0; i < 5; ++i) {
+        int cx = coord(gen);
+        int cy = coord(gen);
+        int cz = coord(gen);
+        int r  = radius(gen);
+        int r2 = r * r;
+        for (int dx = -r; dx <= r; ++dx)
+            for (int dy = -r; dy <= r; ++dy)
+                for (int dz = -r; dz <= r; ++dz) {
+                    if (dx*dx + dy*dy + dz*dz <= r2) {
+                        int x = cx + dx;
+                        int y = cy + dy;
+                        int z = cz + dz;
+                        if (x >= 0 && y >= 0 && z >= 0) {
+                            map[GlobalPosition{static_cast<std::uint32_t>(x),
+                                                static_cast<std::uint32_t>(y),
+                                                static_cast<std::uint32_t>(z)}] = 1;
+                        }
+                    }
+                }
+    }
+    return map;
+}
+
+/// @brief Count how many elements of lhs exist in rhs.
+static std::size_t intersection_size(layered_map<int> const& lhs,
+                                     layered_map<int> const& rhs) {
+    std::size_t count = 0;
+    for (auto it = lhs.cbegin(); it != lhs.cend(); ++it)
+        if (rhs.find(it->first) != rhs.cend()) ++count;
+    return count;
+}
+
+TEST_CASE("extrude and inset operations") {
+    auto box = make_box(GlobalPosition{0,0,0}, GlobalPosition{3,3,3});
+    auto inner = inset(box);
+    CHECK(inner.size() == 1);
+    CHECK(inner.find(GlobalPosition{1,1,1}) != inner.end());
+    auto grown = extrude(inner);
+    for (auto const& [gp, v] : inner)
+        CHECK(grown.find(gp) != grown.end());
+    CHECK(grown.size() > inner.size());
+}
+
+TEST_CASE("CECD accuracy synthetic") {
+    for (int seed = 0; seed < 3; ++seed) {
+        auto shape = make_random_shape(seed);
+        auto layers = core_expanding_convex_decomposition(shape);
+        layered_map<int> merged;
+        for (auto const& layer : layers)
+            for (auto it = layer.cbegin(); it != layer.cend(); ++it)
+                merged.insert({it->first, it->second});
+        double acc = static_cast<double>(intersection_size(shape, merged)) /
+                     static_cast<double>(shape.size());
+        CHECK(acc >= 0.95);
+    }
+}
+


### PR DESCRIPTION
## Summary
- extend `layered_map_algo` with cardinal offset helper
- cleanup extrude/inset implementations
- fix random shape generation for CECD tests

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_b_684360af8778832bae2cc6e1a2a79aaa