### PR TITLE
Implement lazy set operation views

### DIFF
--- a/include/chunk_map.h
+++ b/include/chunk_map.h
@@ -14,6 +14,7 @@
 
 #include "arrow_proxy.h"
 #include "positions.h"
+#include "set_views.h"
     
 
 template <
@@ -189,11 +190,30 @@ public:
         return const_iterator(this, chunks_.end(), typename InnerMap::const_iterator());
     }
 
-    /// @brief Call functor for each element in the intersection of two maps.
-    template<typename Fn>
-    static void for_each_intersection(const chunk_map& lhs,
-                                      const chunk_map& rhs,
-                                      Fn&& fn);
+    /// @brief Begin iterator for constant map.
+    const_iterator begin() const { return cbegin(); }
+    /// @brief End iterator for constant map.
+    const_iterator end() const { return cend(); }
+
+    /// @brief Lazy overlap view of two maps.
+    static auto overlap(const chunk_map& lhs, const chunk_map& rhs);
+    /// @brief Overlap adaptor for piping.
+    static auto overlap(const chunk_map& rhs);
+
+    /// @brief Lazy subtraction view of two maps.
+    static auto subtract(const chunk_map& lhs, const chunk_map& rhs);
+    /// @brief Subtract adaptor for piping.
+    static auto subtract(const chunk_map& rhs);
+
+    /// @brief Lazy merge view of two maps.
+    static auto merge(const chunk_map& lhs, const chunk_map& rhs);
+    /// @brief Merge adaptor for piping.
+    static auto merge(const chunk_map& rhs);
+
+    /// @brief Lazy exclusive view of two maps.
+    static auto exclusive(const chunk_map& lhs, const chunk_map& rhs);
+    /// @brief Exclusive adaptor for piping.
+    static auto exclusive(const chunk_map& rhs);
 
 private:
     OuterMap chunks_;
@@ -314,19 +334,63 @@ public:
 };
 
 template<typename T, typename InnerMap, typename OuterMap>
-template<typename Fn>
-void chunk_map<T, InnerMap, OuterMap>::for_each_intersection(const chunk_map& lhs,
-                                                             const chunk_map& rhs,
-                                                             Fn&& fn)
+auto chunk_map<T, InnerMap, OuterMap>::overlap(const chunk_map& lhs,
+                                               const chunk_map& rhs)
 {
-    for (const auto& [cp, left] : lhs.chunks_) {
-        auto it = rhs.chunks_.find(cp);
-        if (it == rhs.chunks_.end()) continue;
-        InnerMap::for_each_intersection(left, it->second,
-            [&](const typename InnerMap::key_type& lp, const T& val) {
-                fn(combine(cp, lp), val);
-            });
-    }
+    return views::overlap(lhs, rhs,
+        [](auto const& a, auto const& b) { return a.first < b.first; });
+}
+
+template<typename T, typename InnerMap, typename OuterMap>
+auto chunk_map<T, InnerMap, OuterMap>::overlap(const chunk_map& rhs)
+{
+    return views::overlap(rhs,
+        [](auto const& a, auto const& b) { return a.first < b.first; });
+}
+
+template<typename T, typename InnerMap, typename OuterMap>
+auto chunk_map<T, InnerMap, OuterMap>::subtract(const chunk_map& lhs,
+                                                const chunk_map& rhs)
+{
+    return views::subtract(lhs, rhs,
+        [](auto const& a, auto const& b) { return a.first < b.first; });
+}
+
+template<typename T, typename InnerMap, typename OuterMap>
+auto chunk_map<T, InnerMap, OuterMap>::subtract(const chunk_map& rhs)
+{
+    return views::subtract(rhs,
+        [](auto const& a, auto const& b) { return a.first < b.first; });
+}
+
+template<typename T, typename InnerMap, typename OuterMap>
+auto chunk_map<T, InnerMap, OuterMap>::merge(const chunk_map& lhs,
+                                             const chunk_map& rhs)
+{
+    return views::merge(lhs, rhs,
+        [](auto const& a, auto const& b) { return a.first < b.first; });
+}
+
+template<typename T, typename InnerMap, typename OuterMap>
+auto chunk_map<T, InnerMap, OuterMap>::merge(const chunk_map& rhs)
+{
+    return views::merge(rhs,
+        [](auto const& a, auto const& b) { return a.first < b.first; });
+}
+
+template<typename T, typename InnerMap, typename OuterMap>
+auto chunk_map<T, InnerMap, OuterMap>::exclusive(const chunk_map& lhs,
+                                                 const chunk_map& rhs)
+{
+    return views::exclusive(lhs, rhs,
+        [](auto const& a, auto const& b) { return a.first < b.first; });
+}
+
+template<typename T, typename InnerMap, typename OuterMap>
+auto chunk_map<T, InnerMap, OuterMap>::exclusive(const chunk_map& rhs)
+{
+    return views::exclusive(rhs,
+        [](auto const& a, auto const& b) { return a.first < b.first; });
 }
 
 /// @brief Write elements present in both chunk_maps to output.
@@ -335,8 +399,41 @@ OutIt set_intersection(const chunk_map<T, InnerMap, OuterMap>& lhs,
                        const chunk_map<T, InnerMap, OuterMap>& rhs,
                        OutIt out)
 {
-    chunk_map<T, InnerMap, OuterMap>::for_each_intersection(lhs, rhs,
-        [&](GlobalPosition gp, const T& val) { *out++ = std::pair{gp, val}; });
+    for (auto&& e : chunk_map<T, InnerMap, OuterMap>::overlap(lhs, rhs))
+        *out++ = e;
+    return out;
+}
+
+/// @brief Write elements present in lhs but not rhs to output iterator.
+template<typename T, typename InnerMap, typename OuterMap, typename OutIt>
+OutIt set_difference(const chunk_map<T, InnerMap, OuterMap>& lhs,
+                     const chunk_map<T, InnerMap, OuterMap>& rhs,
+                     OutIt out)
+{
+    for (auto&& e : chunk_map<T, InnerMap, OuterMap>::subtract(lhs, rhs))
+        *out++ = e;
+    return out;
+}
+
+/// @brief Write all unique elements from both maps to output iterator.
+template<typename T, typename InnerMap, typename OuterMap, typename OutIt>
+OutIt set_union(const chunk_map<T, InnerMap, OuterMap>& lhs,
+                const chunk_map<T, InnerMap, OuterMap>& rhs,
+                OutIt out)
+{
+    for (auto&& e : chunk_map<T, InnerMap, OuterMap>::merge(lhs, rhs))
+        *out++ = e;
+    return out;
+}
+
+/// @brief Write elements present in exactly one map to output iterator.
+template<typename T, typename InnerMap, typename OuterMap, typename OutIt>
+OutIt set_symmetric_difference(const chunk_map<T, InnerMap, OuterMap>& lhs,
+                               const chunk_map<T, InnerMap, OuterMap>& rhs,
+                               OutIt out)
+{
+    for (auto&& e : chunk_map<T, InnerMap, OuterMap>::exclusive(lhs, rhs))
+        *out++ = e;
     return out;
 }
 

--- a/include/layered_map_algo.h
+++ b/include/layered_map_algo.h
@@ -24,12 +24,8 @@ OutIt set_intersection(const layered_map<T>& lhs,
                        const layered_map<T>& rhs,
                        OutIt out)
 {
-    chunk_map<T, bucket_map<LocalPosition, T>>::for_each_intersection(
-        lhs, rhs,
-        [&](GlobalPosition gp, const T& val)
-        {
-            *out++ = std::pair{gp, val};
-        });
+    for (auto&& e : lhs | chunk_map<T, bucket_map<LocalPosition, T>>::overlap(rhs))
+        *out++ = e;
     return out;
 }
 
@@ -47,12 +43,8 @@ template<typename T>
 layered_map<T> overlap(layered_map<T> const& lhs, layered_map<T> const& rhs)
 {
     layered_map<T> out;
-    chunk_map<T, bucket_map<LocalPosition, T>>::for_each_intersection(
-        lhs, rhs,
-        [&](GlobalPosition gp, const T& val)
-        {
-            out.insert({gp, val});
-        });
+    for (auto&& e : lhs | chunk_map<T, bucket_map<LocalPosition, T>>::overlap(rhs))
+        out.insert(e);
     return out;
 }
 

--- a/include/set_views.h
+++ b/include/set_views.h
@@ -1,0 +1,187 @@
+#pragma once
+
+#include <ranges>
+#include <functional>
+#include "arrow_proxy.h"
+
+/// @brief Set operation enumeration used by set_view.
+enum class set_op { overlap, subtract, merge, exclusive };
+
+namespace detail {
+
+    /// @brief Iterator implementing lazy set algorithms.
+    template<set_op Op, std::forward_iterator I1, std::sentinel_for<I1> S1,
+             std::forward_iterator I2, std::sentinel_for<I2> S2, typename Comp>
+    class set_iter {
+    public:
+        using value_type = std::remove_cvref_t<std::iter_reference_t<I1>>;
+        using reference  = std::iter_reference_t<I1>;
+        using pointer    = arrow_proxy<reference>;
+        using difference_type = std::ptrdiff_t;
+        using iterator_concept = std::forward_iterator_tag;
+
+        /// @brief Construct iterator with range state.
+        set_iter(I1 it1, S1 end1, I2 it2, S2 end2, const Comp* comp)
+            : it1_(it1), end1_(end1), it2_(it2), end2_(end2), comp_(comp)
+        { satisfy(); }
+
+        /// @brief Dereference current element.
+        reference operator*() const { return use_first_ ? *it1_ : *it2_; }
+        /// @brief Arrow operator for structured bindings.
+        pointer operator->() const { return pointer{**this}; }
+
+        /// @brief Pre-increment iterator.
+        set_iter& operator++()
+        {
+            advance();
+            satisfy();
+            return *this;
+        }
+        /// @brief Post-increment iterator.
+        set_iter operator++(int) { auto t = *this; ++(*this); return t; }
+
+        /// @brief Equality comparison with sentinel.
+        bool operator==(std::default_sentinel_t) const
+        {
+            if constexpr (Op == set_op::overlap || Op == set_op::subtract)
+                return it1_ == end1_;
+            else
+                return it1_ == end1_ && it2_ == end2_;
+        }
+
+    private:
+        void advance()
+        {
+            if constexpr (Op == set_op::overlap) {
+                ++it1_; ++it2_;
+            } else if constexpr (Op == set_op::subtract) {
+                ++it1_;
+            } else if constexpr (Op == set_op::merge) {
+                if (it1_ == end1_) { ++it2_; }
+                else if (it2_ == end2_) { ++it1_; }
+                else if ((*comp_)(*it1_, *it2_)) { ++it1_; }
+                else if ((*comp_)(*it2_, *it1_)) { ++it2_; }
+                else { ++it1_; ++it2_; }
+            } else { // exclusive
+                if (use_first_) ++it1_; else ++it2_;
+            }
+        }
+
+        void satisfy()
+        {
+            if constexpr (Op == set_op::overlap) {
+                while (it1_ != end1_ && it2_ != end2_) {
+                    if ((*comp_)(*it1_, *it2_)) ++it1_;
+                    else if ((*comp_)(*it2_, *it1_)) ++it2_;
+                    else break;
+                }
+                use_first_ = true;
+            } else if constexpr (Op == set_op::subtract) {
+                while (it1_ != end1_ && it2_ != end2_) {
+                    if ((*comp_)(*it1_, *it2_)) break;
+                    if ((*comp_)(*it2_, *it1_)) ++it2_;
+                    else { ++it1_; ++it2_; }
+                }
+                use_first_ = true;
+            } else if constexpr (Op == set_op::merge) {
+                if (it1_ == end1_) { use_first_ = false; return; }
+                if (it2_ == end2_) { use_first_ = true; return; }
+                if ((*comp_)(*it1_, *it2_)) use_first_ = true;
+                else if ((*comp_)(*it2_, *it1_)) use_first_ = false;
+                else use_first_ = true;
+            } else { // exclusive
+                while (true) {
+                    if (it1_ == end1_) { use_first_ = false; break; }
+                    if (it2_ == end2_) { use_first_ = true; break; }
+                    if ((*comp_)(*it1_, *it2_)) { use_first_ = true; break; }
+                    if ((*comp_)(*it2_, *it1_)) { use_first_ = false; break; }
+                    ++it1_; ++it2_;
+                }
+            }
+        }
+
+        I1  it1_{}; ///< @brief Iterator into first range.
+        S1  end1_{}; ///< @brief Sentinel for first range.
+        I2  it2_{}; ///< @brief Iterator into second range.
+        S2  end2_{}; ///< @brief Sentinel for second range.
+        const Comp* comp_{nullptr}; ///< @brief Pointer to comparator.
+        bool use_first_{true}; ///< @brief Which iterator provides current value.
+    };
+
+    /// @brief Helper view storing two ranges for set operations.
+    template<set_op Op, std::ranges::forward_range R1, std::ranges::forward_range R2, typename Comp>
+    class set_view : public std::ranges::view_interface<set_view<Op,R1,R2,Comp>> {
+        using I1 = std::ranges::iterator_t<R1>;
+        using S1 = std::ranges::sentinel_t<R1>;
+        using I2 = std::ranges::iterator_t<R2>;
+        using S2 = std::ranges::sentinel_t<R2>;
+    public:
+        /// @brief Construct view from ranges and comparator.
+        set_view(R1 r1, R2 r2, Comp comp)
+            : r1_(std::move(r1)), r2_(std::move(r2)), comp_(std::move(comp)) {}
+
+        /// @brief Iterator to first element.
+        auto begin()
+        {
+            return set_iter<Op,I1,S1,I2,S2,Comp>{std::ranges::begin(r1_), std::ranges::end(r1_),
+                                                std::ranges::begin(r2_), std::ranges::end(r2_), &comp_};
+        }
+        /// @brief End sentinel.
+        std::default_sentinel_t end() { return {}; }
+    private:
+        R1   r1_; ///< @brief First range.
+        R2   r2_; ///< @brief Second range.
+        Comp comp_; ///< @brief Comparator instance.
+    };
+
+    template<set_op Op, typename R2, typename Comp>
+    struct binder {
+        R2 r2; ///< @brief Stored second range.
+        Comp comp; ///< @brief Stored comparator.
+        template<std::ranges::forward_range R1>
+        friend auto operator|(R1&& r1, binder b)
+        {
+            return set_view<Op, std::views::all_t<R1>, R2, Comp>(std::views::all(std::forward<R1>(r1)), b.r2, b.comp);
+        }
+    };
+
+    template<set_op Op>
+    struct view_adaptor {
+        template<std::ranges::forward_range R1, std::ranges::forward_range R2, typename Comp>
+        auto operator()(R1&& r1, R2&& r2, Comp comp) const
+        {
+            return set_view<Op, std::views::all_t<R1>, std::views::all_t<R2>, Comp>(
+                std::views::all(std::forward<R1>(r1)),
+                std::views::all(std::forward<R2>(r2)), comp);
+        }
+        template<std::ranges::forward_range R2, typename Comp>
+        auto operator()(R2&& r2, Comp comp) const
+        {
+            return binder<Op, std::views::all_t<R2>, Comp>{ std::views::all(std::forward<R2>(r2)), comp };
+        }
+        template<std::ranges::forward_range R2>
+        auto operator()(R2&& r2) const
+        {
+            return binder<Op, std::views::all_t<R2>, std::ranges::less>{
+                std::views::all(std::forward<R2>(r2)), {} };
+        }
+        template<std::ranges::forward_range R1, std::ranges::forward_range R2>
+        auto operator()(R1&& r1, R2&& r2) const
+        {
+            return (*this)(std::forward<R1>(r1), std::forward<R2>(r2), std::ranges::less{});
+        }
+    };
+
+} // namespace detail
+
+namespace views {
+    /// @brief Lazy overlap of two sorted ranges.
+    inline constexpr detail::view_adaptor<set_op::overlap> overlap{};
+    /// @brief Lazy subtraction of two sorted ranges.
+    inline constexpr detail::view_adaptor<set_op::subtract> subtract{};
+    /// @brief Lazy merge of two sorted ranges.
+    inline constexpr detail::view_adaptor<set_op::merge> merge{};
+    /// @brief Lazy exclusive difference of two sorted ranges.
+    inline constexpr detail::view_adaptor<set_op::exclusive> exclusive{};
+} // namespace views
+

--- a/tests/test_bucket_map.cpp
+++ b/tests/test_bucket_map.cpp
@@ -133,7 +133,7 @@ TEST_CASE("ranges to move map") {
     CHECK(src.empty());
 }
 
-TEST_CASE("optimized set_intersection") {
+TEST_CASE("optimized overlap view") {
     bucket_map<std::size_t, int> lhs;
     lhs.insert_or_assign(1, 1);
     lhs.insert_or_assign(5, 2);
@@ -143,10 +143,49 @@ TEST_CASE("optimized set_intersection") {
     rhs.insert_or_assign(5, 8);
     rhs.insert_or_assign(70, 9);
 
-    std::vector<std::pair<std::size_t, int>> inter;
-    set_intersection(lhs, rhs, std::back_inserter(inter));
+    auto inter = std::ranges::to<std::vector<std::pair<std::size_t, int>>>(
+        lhs | bucket_map<std::size_t, int>::overlap(rhs));
 
     std::vector<std::pair<std::size_t, int>> expected{{5, 2}, {70, 3}};
     CHECK(inter == expected);
+}
+
+TEST_CASE("optimized subtract view") {
+    bucket_map<std::size_t, int> lhs;
+    lhs.insert_or_assign(1, 1);
+    lhs.insert_or_assign(5, 2);
+    lhs.insert_or_assign(70, 3);
+    bucket_map<std::size_t, int> rhs;
+    rhs.insert_or_assign(5, 8);
+    rhs.insert_or_assign(80, 9);
+    auto diff = std::ranges::to<std::vector<std::pair<std::size_t, int>>>(
+        lhs | bucket_map<std::size_t, int>::subtract(rhs));
+    std::vector<std::pair<std::size_t, int>> expected{{1,1},{70,3}};
+    CHECK(diff == expected);
+}
+
+TEST_CASE("optimized merge view") {
+    bucket_map<std::size_t, int> lhs;
+    lhs.insert_or_assign(1, 1);
+    bucket_map<std::size_t, int> rhs;
+    rhs.insert_or_assign(0, 7);
+    rhs.insert_or_assign(1, 5);
+    auto uni = std::ranges::to<std::vector<std::pair<std::size_t, int>>>(
+        lhs | bucket_map<std::size_t, int>::merge(rhs));
+    std::vector<std::pair<std::size_t, int>> expected{{0,7},{1,1}};
+    CHECK(uni == expected);
+}
+
+TEST_CASE("optimized exclusive view") {
+    bucket_map<std::size_t, int> lhs;
+    lhs.insert_or_assign(1, 1);
+    lhs.insert_or_assign(5, 2);
+    bucket_map<std::size_t, int> rhs;
+    rhs.insert_or_assign(5, 8);
+    rhs.insert_or_assign(9, 9);
+    auto sym = std::ranges::to<std::vector<std::pair<std::size_t, int>>>(
+        lhs | bucket_map<std::size_t, int>::exclusive(rhs));
+    std::vector<std::pair<std::size_t, int>> expected{{1,1},{9,9}};
+    CHECK(sym == expected);
 }
 


### PR DESCRIPTION
## Summary
- introduce pipeable set views for bucket_map and chunk_map
- update layered_map algorithms to use the new pipe syntax
- refactor unit tests to chain set operations via | syntax
- improve generic std::ranges::to conversion helper
- rename set operation APIs to `merge`, `overlap`, `subtract`, and `exclusive`

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_b_684512d5f7f0832bafcf2ec6915f78a8