### PR TITLE
Add RAII benchmark helper

### DIFF
--- a/include/benchmark.h
+++ b/include/benchmark.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "doctest.h"
+#include <chrono>
+#include <string_view>
+
+namespace bench {
+
+/// @brief RAII timer used for simple benchmarks.
+class BenchmarkGuard {
+public:
+    /// @brief Begin timing with a label.
+    BenchmarkGuard(std::string_view name,
+                   const char* file,
+                   int line);
+
+    /// @brief Stop timing and report the result.
+    ~BenchmarkGuard();
+
+    /// @brief Allow use in single iteration for loops.
+    explicit operator bool() const { return active_; }
+
+    /// @brief End the timing loop.
+    void stop() { active_ = false; }
+
+private:
+    std::string_view name_{}; ///< Benchmark label.
+    const char* file_{};      ///< Source file location.
+    int line_{};              ///< Source line location.
+    std::chrono::steady_clock::time_point start_{}; ///< Start point of timing.
+    bool active_{true};       ///< Loop state flag.
+};
+
+inline BenchmarkGuard::BenchmarkGuard(std::string_view name,
+                                      const char* file,
+                                      int line)
+    : name_{name}, file_{file}, line_{line}, start_{std::chrono::steady_clock::now()} {}
+
+inline BenchmarkGuard::~BenchmarkGuard() {
+    auto end = std::chrono::steady_clock::now();
+    auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(end - start_).count();
+    INFO(name_ << " ms: " << ms);
+}
+
+} // namespace bench
+
+#define BENCHMARK(name) \
+    for (bench::BenchmarkGuard bench_guard{name, __FILE__, __LINE__}; bench_guard; bench_guard.stop())
+

--- a/tests/bench_layered_map.cpp
+++ b/tests/bench_layered_map.cpp
@@ -1,0 +1,40 @@
+#include "doctest.h"
+#include "layered_map.h"
+#include "layered_map_algo.h"
+#include "aabb.h"
+#include "benchmark.h"
+
+/// @brief Create a filled axis aligned box.
+static layered_map<int> make_box(GlobalPosition min_corner,
+                                 GlobalPosition max_corner,
+                                 int value = 1)
+{
+    layered_map<int> map;
+    for (GlobalPosition p : GlobalAabb{min_corner, max_corner})
+        map[p] = value;
+    return map;
+}
+
+TEST_CASE("layered_map csg benchmark") {
+    auto lhs = make_box({0,0,0}, {50,50,50});
+    auto rhs = make_box({25,25,25}, {75,75,75});
+
+    layered_map<int> uni;
+    BENCHMARK("union") {
+        uni = lhs | rhs;
+    }
+
+    layered_map<int> inter;
+    BENCHMARK("intersection") {
+        inter = lhs & rhs;
+    }
+
+    layered_map<int> diff;
+    BENCHMARK("difference") {
+        diff = lhs - rhs;
+    }
+
+    CHECK(uni.size() > 0);
+    CHECK(inter.size() > 0);
+    CHECK(diff.size() > 0);
+}

--- a/tests/test_benchmark.cpp
+++ b/tests/test_benchmark.cpp
@@ -1,0 +1,16 @@
+#include "doctest.h"
+#include "benchmark.h"
+#include <thread>
+#include <type_traits>
+
+namespace checks {
+    static_assert(std::movable<bench::BenchmarkGuard>);
+    static_assert(std::is_nothrow_destructible_v<bench::BenchmarkGuard>);
+}
+
+TEST_CASE("benchmark guard basic") {
+    BENCHMARK("sleep") {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+    }
+    CHECK(true);
+}


### PR DESCRIPTION
## Summary
- add reusable BenchmarkGuard for RAII-style timing
- refactor layered map benchmark to use the new helper
- add a small test exercising BenchmarkGuard

## Testing
- `cmake -B build -S .`
- `cmake --build build`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_b_68462fd44b68832bbca6d50c18a541ad